### PR TITLE
Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm install --save @hunteroi/discord-temp-channels
 
 ## Examples
 
-See [./example/withTempChannelsManager.js](example/withTempChannelsManager.js) and [./example/withClientWithTempManager.js](example/withClientWithTempManager.js).
+See [./examples/withTempChannelsManager.js](examples/withTempChannelsManager.js) and [./examples/withClientWithTempManager.js](examples/withClientWithTempManager.js).
 
 ## Events
 

--- a/examples/withClientWithTempManager.js
+++ b/examples/withClientWithTempManager.js
@@ -21,7 +21,9 @@ client.on('ready', () => {
     childAutoDeleteIfOwnerLeaves: false,
     childAutoDeleteIfParentGetsUnregistered: true,
     childVoiceFormat: (str, count) => `Example #${count} | ${str}`,
-    childVoiceFormatRegex: /^Example #\d+ \|/
+    childVoiceFormatRegex: /^Example #\d+ \|/,
+    childMaxUsers: 3,
+    childBitrate: 64000
   });
 
   client.on('messageCreate', (message) => message.content === 'unregister' && manager.unregisterChannel('CHANNEL_ID'));

--- a/examples/withTempChannelsManager.js
+++ b/examples/withTempChannelsManager.js
@@ -23,7 +23,9 @@ client.on('ready', () => {
     childAutoDeleteIfParentGetsUnregistered: true,
     childAutoDeleteIfOwnerLeaves: false,
     childVoiceFormat: (str, count) => `Example #${count} | ${str}`,
-    childVoiceFormatRegex: /^Example #\d+ \|/
+    childVoiceFormatRegex: /^Example #\d+ \|/,
+    childMaxUsers: 3,
+    childBitrate: 64000
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hunteroi/discord-temp-channels",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Based on Androz2091's package, this is a simple framework to facilitate the creation of a temporary voice & text channels system using Discord.js",
   "main": "lib/index.js",
   "bugs": {


### PR DESCRIPTION
- [x] Remove the typo in the paths from the README in 9cf3457c0729ffdb5dc28cfe8365f168792bb0de
- [x] Add `childMaxUsers` and `childBitrate` to the examples so that users know they exist in e6493d1f0e8e08fb2439202e4df35084c7a3b6ba & 7e7a7fbfa382c1c585275b0f983f2f1ae378ccd7

Co-authored by @justman10000 via #7 