### PR TITLE
edit: remove option parameters when using childShouldBeACopyOfParent:…

### DIFF
--- a/src/TempChannelsManager.ts
+++ b/src/TempChannelsManager.ts
@@ -177,10 +177,7 @@ export class TempChannelsManager extends VoiceChannelsManager {
         let voiceChannel: VoiceChannel | null = null;
         if (parent.options.childShouldBeACopyOfParent) {
             voiceChannel = await parentChannel.clone({
-                name,
-                parent: categoryChannel?.id ?? null,
-                bitrate: parent.options.childBitrate,
-                userLimit: parent.options.childMaxUsers
+                name
             });
         } else {
             voiceChannel = await channel.guild.channels.create({


### PR DESCRIPTION
Addition to https://github.com/HunteRoi/discord-temp-channels/pull/11

This would result that the channel will be a full clone of the parent channel exept the naming pattern. In my opinion  this might give that new added parameter more use of it.